### PR TITLE
Php5 xdebug fix

### DIFF
--- a/php5/fpm/Dockerfile
+++ b/php5/fpm/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update --fix-missing && apt-get install -y \
         libxml2-dev \
         libicu-dev \
         libxslt-dev \
-        php5-xdebug \
         wget libcurl4-openssl-dev \
         ssh-client git vim \
     && rm -rf /var/lib/apt/lists/*
@@ -22,9 +21,8 @@ RUN docker-php-ext-install mcrypt bcmath mysql mysqli pdo_mysql mbstring ftp soa
     && docker-php-ext-install gd
 
 # Install xdebug
-# workaround for https://github.com/docker-library/php/issues/133
-#     - Xdebug breaks on access to class static property
-# Added to apt above
+RUN pecl install xdebug-2.5.5 \
+    && rm -rf /tmp/pear 
 
 # Install blackfire agent
 RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
@@ -34,8 +32,7 @@ RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
 
 # Enable debug extension
 RUN echo "extension=blackfire.so\nblackfire.agent_socket=\${BLACKFIRE_PORT}" > $PHP_INI_DIR/conf.d/blackfire.ini \
-    && echo "zend_extension=/usr/lib/php5/20131226/xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini
-
+    && echo "zend_extension=`ls /usr/local/lib/php/extensions/no-debug-non-zts-*/xdebug.so`" > /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install Magerun
 RUN wget -nv https://files.magerun.net/n98-magerun-1.97.30.phar -O /usr/local/bin/n98-magerun \

--- a/php72/fpm/Dockerfile
+++ b/php72/fpm/Dockerfile
@@ -1,11 +1,11 @@
-FROM php:7.2-rc-fpm
+FROM php:7.2-fpm
 MAINTAINER Jeroen Boersma <jeroen@srcode.nl>
 
 RUN apt-get update --fix-missing && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
-        libpng12-dev \
+        libpng-dev \
         msmtp \
         imagemagick \
         libssl-dev \
@@ -16,12 +16,13 @@ RUN apt-get update --fix-missing && apt-get install -y \
         ssh-client git vim \
     && rm -rf /var/lib/apt/lists/*
 
-RUN docker-php-ext-install mcrypt bcmath mysqli pdo_mysql mbstring ftp soap zip intl opcache xsl \
+RUN pecl install mcrypt-1.0.1 && docker-php-ext-enable mcrypt \
+    && docker-php-ext-install bcmath mysqli pdo_mysql mbstring ftp soap zip intl opcache xsl \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd
 
 # Install xdebug
-RUN wget -nv https://xdebug.org/files/xdebug-2.5.5.tgz \
+RUN wget -nv https://xdebug.org/files/xdebug-2.6.0.tgz \
     && tar -xvzf xdebug-*.tgz \
     && cd xdebug-* \
     && phpize \


### PR DESCRIPTION
The PHP5 Image can no longer be built since the php5-xdebug package is no longer in the current os version's APT repositories.
The use of the apt version of the xdebug package was a workaround for https://github.com/docker-library/php/issues/133 .
After building the image locally with a new version of xdebug (2.5.5) this bug is no longer present.
And the image is buildable again.