### PR TITLE
Install xdebug in php80-fpm

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -31,13 +31,24 @@ RUN mkdir -p /tmp/sodium \
     && make install \
     && rm -rf /tmp/sodium
 
+# Install imagick
+RUN cd /tmp \
+    && git clone https://github.com/Imagick/imagick \
+    && cd imagick \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && docker-php-ext-enable imagick \
+    && rm -rf /tmp/imagick
+
 RUN docker-php-ext-install bcmath mysqli pdo_mysql soap zip intl opcache xsl pcntl sockets \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd
 
-# Install xdebug and redis
-RUN pecl install imagick xdebug redis libsodium apcu \
-    && docker-php-ext-enable imagick xdebug redis sodium apcu \
+# Install PECL extensions
+RUN pecl install xdebug redis apcu \
+    && docker-php-ext-enable xdebug redis apcu \
     && rm -rf /tmp/pear
 
 # Install blackfire agent
@@ -62,11 +73,13 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/composer-1.phar -O /usr/local/bin/composer1 \
-    && chmod ugo+rx /usr/local/bin/composer1 \
-    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer
-RUN wget -nv https://getcomposer.org/composer-2.phar -O /usr/local/bin/composer2 \
-    && chmod ugo+rx /usr/local/bin/composer2
+RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
+    && for version in 1 2; \
+        do php composer-setup.php "--$version" --install-dir=/usr/local/bin --filename="composer$version"; \
+        chmod ugo+rx /usr/local/bin/"composer$version"; \
+    done \
+    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && rm composer-setup.php
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/
@@ -82,4 +95,3 @@ RUN groupadd -g 1000 app && \
     useradd -g 1000 -u 1000 -d /data -s /bin/bash app
 
 WORKDIR /data
-

--- a/php56/fpm/Dockerfile
+++ b/php56/fpm/Dockerfile
@@ -24,7 +24,7 @@ RUN docker-php-ext-install mcrypt bcmath mysql mysqli pdo_mysql mbstring ftp soa
 # Install xdebug and redis
 RUN pecl install xdebug-2.5.5 redis-4.2.0 \
     && docker-php-ext-enable xdebug redis \
-    && rm -rf /tmp/pear 
+    && rm -rf /tmp/pear
 
 # Install blackfire agent
 RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
@@ -47,9 +47,9 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/installer -O /tmp/composer-setup.php \
-    && php /tmp/composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer \
-    && rm /tmp/composer-setup.php
+RUN curl -sS https://getcomposer.org/installer \
+        | php -- --1 --install-dir=/usr/local/bin --filename=composer \
+    chmod ugo+rx /usr/local/bin/composer
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php70/fpm/Dockerfile
+++ b/php70/fpm/Dockerfile
@@ -61,9 +61,9 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/installer -O /tmp/composer-setup.php \
-    && php /tmp/composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer \
-    && rm /tmp/composer-setup.php
+RUN curl -sS https://getcomposer.org/installer \
+        | php -- --1 --install-dir=/usr/local/bin --filename=composer \
+    chmod ugo+rx /usr/local/bin/composer
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php71/fpm/Dockerfile
+++ b/php71/fpm/Dockerfile
@@ -61,9 +61,9 @@ RUN wget -nv https://files.magerun.net/n98-magerun2-3.2.0.phar -O /usr/local/bin
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/installer -O /tmp/composer-setup.php \
-    && php /tmp/composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer \
-    && rm /tmp/composer-setup.php
+RUN curl -sS https://getcomposer.org/installer \
+        | php -- --1 --install-dir=/usr/local/bin --filename=composer \
+    chmod ugo+rx /usr/local/bin/composer
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php72/fpm/Dockerfile
+++ b/php72/fpm/Dockerfile
@@ -61,11 +61,13 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/composer-1.phar -O /usr/local/bin/composer1 \
-    && chmod ugo+rx /usr/local/bin/composer1 \
-    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer
-RUN wget -nv https://getcomposer.org/composer-2.phar -O /usr/local/bin/composer2 \
-    && chmod ugo+rx /usr/local/bin/composer2
+RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
+    && for version in 1 2; \
+        do php composer-setup.php "--$version" --install-dir=/usr/local/bin --filename="composer$version"; \
+        chmod ugo+rx /usr/local/bin/"composer$version"; \
+    done \
+    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && rm composer-setup.php
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php72/fpm/conf/php.ini
+++ b/php72/fpm/conf/php.ini
@@ -5,8 +5,8 @@ memory_limit = 512M
 log_errors = 1
 error_reporting = E_ALL
 
-xdebug.max_nesting_level = 1024
-
 xdebug.client_host = 172.17.0.1
-xdebug.mode=develop,debug
+xdebug.discover_client_host = true
+xdebug.max_nesting_level = 1024
+xdebug.mode=coverage,debug,develop
 

--- a/php73/fpm/Dockerfile
+++ b/php73/fpm/Dockerfile
@@ -61,11 +61,13 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/composer-1.phar -O /usr/local/bin/composer1 \
-    && chmod ugo+rx /usr/local/bin/composer1 \
-    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer
-RUN wget -nv https://getcomposer.org/composer-2.phar -O /usr/local/bin/composer2 \
-    && chmod ugo+rx /usr/local/bin/composer2
+RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
+    && for version in 1 2; \
+        do php composer-setup.php "--$version" --install-dir=/usr/local/bin --filename="composer$version"; \
+        chmod ugo+rx /usr/local/bin/"composer$version"; \
+    done \
+    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && rm composer-setup.php
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php73/fpm/conf/php.ini
+++ b/php73/fpm/conf/php.ini
@@ -5,8 +5,8 @@ memory_limit = 512M
 log_errors = 1
 error_reporting = E_ALL
 
-xdebug.max_nesting_level = 1024
-
 xdebug.client_host = 172.17.0.1
-xdebug.mode=develop,debug
+xdebug.discover_client_host = true
+xdebug.max_nesting_level = 1024
+xdebug.mode=coverage,debug,develop
 

--- a/php74/fpm/Dockerfile
+++ b/php74/fpm/Dockerfile
@@ -62,11 +62,13 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/composer-1.phar -O /usr/local/bin/composer1 \
-    && chmod ugo+rx /usr/local/bin/composer1 \
-    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer
-RUN wget -nv https://getcomposer.org/composer-2.phar -O /usr/local/bin/composer2 \
-    && chmod ugo+rx /usr/local/bin/composer2
+RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
+    && for version in 1 2; \
+        do php composer-setup.php "--$version" --install-dir=/usr/local/bin --filename="composer$version"; \
+        chmod ugo+rx /usr/local/bin/"composer$version"; \
+    done \
+    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && rm composer-setup.php
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php74/fpm/conf/php.ini
+++ b/php74/fpm/conf/php.ini
@@ -5,8 +5,8 @@ memory_limit = 512M
 log_errors = 1
 error_reporting = E_ALL
 
-xdebug.max_nesting_level = 1024
-
 xdebug.client_host = 172.17.0.1
-xdebug.mode=develop,debug
+xdebug.discover_client_host = true
+xdebug.max_nesting_level = 1024
+xdebug.mode=coverage,debug,develop
 

--- a/php80/fpm/Dockerfile
+++ b/php80/fpm/Dockerfile
@@ -31,19 +31,25 @@ RUN mkdir -p /tmp/sodium \
     && make install \
     && rm -rf /tmp/sodium
 
+# Install imagick
+RUN cd /tmp \
+    && git clone https://github.com/Imagick/imagick \
+    && cd imagick \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && docker-php-ext-enable imagick \
+    && rm -rf /tmp/imagick
+
 RUN docker-php-ext-install bcmath mysqli pdo_mysql soap zip intl opcache xsl pcntl sockets \
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd
 
-# Install xdebug
-RUN pecl install xdebug \
-    && docker-php-ext-enable xdebug \
+# Install PECL extensions
+RUN pecl install xdebug redis apcu \
+    && docker-php-ext-enable xdebug redis apcu \
     && rm -rf /tmp/pear
-
-# Install xdebug and redis
-#RUN pecl install imagick xdebug redis libsodium apcu \
-#    && docker-php-ext-enable imagick xdebug redis sodium apcu \
-#    && rm -rf /tmp/pear
 
 # Install blackfire agent
 #RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
@@ -67,11 +73,13 @@ RUN wget -nv https://files.magerun.net/n98-magerun2.phar -O /usr/local/bin/n98-m
     && ln -s /usr/local/bin/n98-magerun2 /usr/local/bin/magerun2
 
 # Install composer
-RUN wget -nv https://getcomposer.org/composer-1.phar -O /usr/local/bin/composer1 \
-    && chmod ugo+rx /usr/local/bin/composer1 \
-    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer
-RUN wget -nv https://getcomposer.org/composer-2.phar -O /usr/local/bin/composer2 \
-    && chmod ugo+rx /usr/local/bin/composer2
+RUN curl -sS https://getcomposer.org/installer --output composer-setup.php \
+    && for version in 1 2; \
+        do php composer-setup.php "--$version" --install-dir=/usr/local/bin --filename="composer$version"; \
+        chmod ugo+rx /usr/local/bin/"composer$version"; \
+    done \
+    && ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && rm composer-setup.php
 
 # Copy config files
 COPY conf/php-fpm.conf /usr/local/etc/

--- a/php80/fpm/Dockerfile
+++ b/php80/fpm/Dockerfile
@@ -35,6 +35,11 @@ RUN docker-php-ext-install bcmath mysqli pdo_mysql soap zip intl opcache xsl pcn
     && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install gd
 
+# Install xdebug
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && rm -rf /tmp/pear
+
 # Install xdebug and redis
 #RUN pecl install imagick xdebug redis libsodium apcu \
 #    && docker-php-ext-enable imagick xdebug redis sodium apcu \

--- a/php80/fpm/Dockerfile
+++ b/php80/fpm/Dockerfile
@@ -52,15 +52,15 @@ RUN pecl install xdebug redis apcu \
     && rm -rf /tmp/pear
 
 # Install blackfire agent
-#RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
-#    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${VERSION} \
-#    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
-#    && mv /tmp/blackfire-*.so `php -r "echo ini_get('extension_dir');"`/blackfire.so \
-#    && docker-php-ext-enable blackfire \
-#    && rm /tmp/blackfire*
+RUN export VERSION=`php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;"` \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${VERSION} \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
+    && mv /tmp/blackfire-*.so `php -r "echo ini_get('extension_dir');"`/blackfire.so \
+    && docker-php-ext-enable blackfire \
+    && rm /tmp/blackfire*
 
 # Enable debug extension
-#RUN echo "blackfire.agent_socket=\${BLACKFIRE_PORT}" > $PHP_INI_DIR/conf.d/blackfire.ini
+RUN echo "blackfire.agent_socket=\${BLACKFIRE_PORT}" > $PHP_INI_DIR/conf.d/blackfire.ini
 
 # Install Magerun
 RUN wget -nv https://files.magerun.net/n98-magerun.phar -O /usr/local/bin/n98-magerun \

--- a/php80/fpm/conf/php.ini
+++ b/php80/fpm/conf/php.ini
@@ -5,7 +5,7 @@ memory_limit = 512M
 log_errors = 1
 error_reporting = E_ALL
 
-xdebug.remote_enable = 1
-xdebug.remote_host = 172.17.0.1
+xdebug.client_host = 172.17.0.1
+xdebug.discover_client_host = true
 xdebug.max_nesting_level = 1024
-
+xdebug.mode=coverage,debug,develop

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,11 @@ for a in php[0-9][0-9]; do
 
     tag=$a-fpm;
     cd ${cwd}/$a/fpm;
-    docker build --tag=srcoder/development-php:${tag} . || exit 1;
+    if ! docker build --tag=srcoder/development-php:${tag} . ; then
+      echo "";
+      echo "Could not build $tag";
+      exit 1;
+    fi
 done
 
 cd ${cwd};


### PR DESCRIPTION
Install the xdebug extension in the PHP 8 FPM image.

The corresponding xdebug settings have been upgraded. The configuration
`xdebug.discover_client_host` has been set to `true` to allow flexible
host configuration for IDEs through HTTP headers.

/cc @JeroenBoersma 