### PR TITLE
added libs needed to create avif images

### DIFF
--- a/php81/fpm/Dockerfile
+++ b/php81/fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod 0755 /usr/local/bin/install-php-extensions && \
 
 # add internal useful tools
 RUN apt-get update --fix-missing \
-    && apt-get install -y ssh-client git vim wget unzip msmtp \
+    && apt-get install -y ssh-client git vim wget unzip msmtp libheif-plugin-aomenc libheif-plugin-svtenc \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/php82/fpm/Dockerfile
+++ b/php82/fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod 0755 /usr/local/bin/install-php-extensions && \
 
 # add internal useful tools
 RUN apt-get update --fix-missing \
-    && apt-get install -y ssh-client git vim wget unzip msmtp \
+    && apt-get install -y ssh-client git vim wget unzip msmtp libheif-plugin-aomenc libheif-plugin-svtenc \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/php83/fpm/Dockerfile
+++ b/php83/fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod 0755 /usr/local/bin/install-php-extensions && \
 
 # add internal useful tools
 RUN apt-get update --fix-missing \
-    && apt-get install -y ssh-client git vim wget unzip msmtp \
+    && apt-get install -y ssh-client git vim wget unzip msmtp libheif-plugin-aomenc libheif-plugin-svtenc \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/php84/fpm/Dockerfile
+++ b/php84/fpm/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod 0755 /usr/local/bin/install-php-extensions && \
 
 # add internal useful tools
 RUN apt-get update --fix-missing \
-    && apt-get install -y ssh-client git vim wget unzip msmtp \
+    && apt-get install -y ssh-client git vim wget unzip msmtp libheif-plugin-aomenc libheif-plugin-svtenc \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/php85/fpm/Dockerfile
+++ b/php85/fpm/Dockerfile
@@ -25,7 +25,7 @@ RUN chmod 0755 /usr/local/bin/install-php-extensions && \
 
 # add internal useful tools
 RUN apt-get update --fix-missing \
-    && apt-get install -y ssh-client git vim wget unzip msmtp \
+    && apt-get install -y ssh-client git vim wget unzip msmtp libheif-plugin-aomenc libheif-plugin-svtenc \
     && rm -rf /var/lib/apt/lists/*
 
 


### PR DESCRIPTION
Ubuntu needs libheif-plugin-aomenc libheif-plugin-svtenc even if libheif is present in order to create AVIF  images. 